### PR TITLE
Fetching the openjdk distribution through conda and not conda-forge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM continuumio/anaconda3
+FROM continuumio/anaconda3:5.3.0
 MAINTAINER phil schatzmann
 RUN apt-get update && apt-get install -y texlive-xetex bzip2 git curl wget && apt-get clean
 RUN conda update -y conda && conda update -y anaconda 
-RUN conda install -y -c conda-forge 'python>=3' nodejs pandas openjdk maven py4j requests jupyterlab beakerx
+RUN conda install -y -c conda-forge 'python>=3' nodejs pandas maven py4j requests jupyterlab beakerx
+RUN conda install -c anaconda openjdk
 RUN npm install --save-dev webpack
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager
 RUN jupyter labextension install beakerx-jupyterlab
@@ -12,5 +13,5 @@ RUN mkdir /home/beakerx
 WORKDIR /home/beakerx
 VOLUME /home/beakerx
 
-EXPOSE 8888
+EXPOSE 8888 
 CMD ["jupyter", "lab", "--no-browser", "--allow-root", "--ip=0.0.0.0" ]


### PR DESCRIPTION
conda-forge fetches openjdk version 11. Scala support for Java 11 is incomplete as mentioned on the Scala website, calusing problems while compiling a scala task. However, conda fetches the openjdk version 8, which works fine for scala. 